### PR TITLE
feat: add Github Actions for PR checks and release

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,49 @@
+name: PR Checks
+on: pull_request
+
+jobs:
+  pr-checks-build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "npm"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build Package
+        run: npm run build
+  pr-checks-code-lint:
+    name: Code Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "npm"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Code Linting
+        run: npm run lint
+  pr-checks-tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: "npm"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Tests
+        run: npm run test

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,34 @@
+name: Pre-release
+on:
+  push:
+    branches:
+      - beta
+      - "exp-*"
+
+jobs:
+  pre-release:
+    name: pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          registry-url: "https://registry.npmjs.org" # This registry URL is necessary for publishing on NPM
+          cache: "npm"
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build Package
+        run: npm run build
+      - name: Pre-Release Package
+        env:
+          HUSKY: 0 # skip the husky hooks
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # should be set in Github repo, need this to publish on NPM
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided by Github Actions, need this to create a GitHub Release
+        run: |
+          npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3 # This action checks-out your repository under $GITHUB_WORKSPACE, so your workflow can access it.
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          registry-url: "https://registry.npmjs.org" # This registry URL is necessary for publishing on NPM
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build Package
+        run: npm run build
+      - name: Release Package
+        env:
+          HUSKY: 0 # skip the husky hooks
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # should be set in Github repo, need this to publish on NPM
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided by Github Actions, need this to create a GitHub Release
+        run: |
+          npx semantic-release

--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ Check out [husky](https://typicode.github.io/husky) docs for more info.
 You can use `npm run commit` to interactively construct correct commit messsage.
 
 Check out [commitlint](https://commitlint.js.org) docs for examples of how to customise.
+
+## Release actions
+
+The following token needs to be set in the Github repo for the `prerelease` and `release` Github Actions to work:
+
+- `secrets.NPM_TOKEN` (need this to publish on NPM)


### PR DESCRIPTION
Following token needs to be set in the Github repo for the `prerelease` and `release` actions to work:
- `secrets.NPM_TOKEN` # need this to publish on NPM