### PR TITLE
chore: bump lokalise eslint version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,33 +1,12 @@
 {
   "settings": {
-    "import/resolver": {
-      "node": {
-        "extensions": [".js", ".ts", ".d.ts"]
-      }
-    },
     "jest": {
       "version": ">= 27"
     }
   },
-  "plugins": ["prettier"],
   "extends": [
     "@lokalise/lokalise-frontend/core",
     "@lokalise/lokalise-frontend/jest",
-    "prettier"
-  ],
-  "rules": {
-    "prettier/prettier": "error"
-  },
-  "overrides": [
-    {
-      "files": ["*.ts"],
-      "extends": ["@lokalise/lokalise-frontend/typescript"]
-    },
-    {
-      "files": ["**/*.cjs"],
-      "env": {
-        "node": true
-      }
-    }
+    "@lokalise/lokalise-frontend/typescript"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@commitlint/cli": "17.4.4",
         "@commitlint/config-conventional": "17.4.4",
         "@commitlint/prompt-cli": "17.4.4",
-        "@lokalise/eslint-config-lokalise-frontend": "0.3.0",
+        "@lokalise/eslint-config-lokalise-frontend": "0.3.1",
         "@semantic-release/changelog": "6.0.2",
         "@semantic-release/commit-analyzer": "9.0.2",
         "@semantic-release/git": "10.0.1",
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@lokalise/eslint-config-lokalise-frontend": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@lokalise/eslint-config-lokalise-frontend/-/eslint-config-lokalise-frontend-0.3.0.tgz",
-      "integrity": "sha512-/BNtqAEx5Aw9EOJmyPwbU4kcNCYWhF49bIZ09xQFrLTZC9X0fSDwhCAq4iX68cmBODqZF3cWDuFi9jFvWPrDFw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@lokalise/eslint-config-lokalise-frontend/-/eslint-config-lokalise-frontend-0.3.1.tgz",
+      "integrity": "sha512-kfgc1R+kc3mhG5Nu1CIBmkXyPDI+hXJAaQY7cZ4G0Nk5BCrEJUAtLIQ6PeVHPMMiW15V31x0mKT4VEMGSJI+YQ==",
       "dev": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": ">= 5",
@@ -946,7 +946,8 @@
         "eslint-plugin-jest": ">= 27",
         "eslint-plugin-jsx-a11y": ">= 6",
         "eslint-plugin-react": ">= 7",
-        "eslint-plugin-react-hooks": ">= 4"
+        "eslint-plugin-react-hooks": ">= 4",
+        "prettier": ">= 2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -11865,9 +11866,9 @@
       }
     },
     "@lokalise/eslint-config-lokalise-frontend": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@lokalise/eslint-config-lokalise-frontend/-/eslint-config-lokalise-frontend-0.3.0.tgz",
-      "integrity": "sha512-/BNtqAEx5Aw9EOJmyPwbU4kcNCYWhF49bIZ09xQFrLTZC9X0fSDwhCAq4iX68cmBODqZF3cWDuFi9jFvWPrDFw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@lokalise/eslint-config-lokalise-frontend/-/eslint-config-lokalise-frontend-0.3.1.tgz",
+      "integrity": "sha512-kfgc1R+kc3mhG5Nu1CIBmkXyPDI+hXJAaQY7cZ4G0Nk5BCrEJUAtLIQ6PeVHPMMiW15V31x0mKT4VEMGSJI+YQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@commitlint/cli": "17.4.4",
     "@commitlint/config-conventional": "17.4.4",
     "@commitlint/prompt-cli": "17.4.4",
-    "@lokalise/eslint-config-lokalise-frontend": "0.3.0",
+    "@lokalise/eslint-config-lokalise-frontend": "0.3.1",
     "@semantic-release/changelog": "6.0.2",
     "@semantic-release/commit-analyzer": "9.0.2",
     "@semantic-release/git": "10.0.1",


### PR DESCRIPTION
Having updated the eslint config, this PR simplifies the configuration required in this template. We still get all the same linting, but now the "logic" is mostly tucked away in the config repo.