### PR TITLE
chore: Enable automerge for Dependabot PRs that pass tests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,3 +47,14 @@ jobs:
         run: npm ci
       - name: Run Tests
         run: npm run test
+
+  automerge:
+    needs: pr-checks-tests
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will help us prevent dependencies from running stale.