### PR TITLE
feat: improve build settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,19 @@ The last thing to do is actually start writing your code! We recommend starting 
 
 ## Customizing the build
 
-The build system uses Vite. It is configured to treat `./src/index.ts` as the entry point of your repository. Feel free to change any particulars in `./vite.config.ts`. In particular if you require multiple entry points, we recommend reviewing Vite's documentation on this here: [Vite Library Mode](https://vitejs.dev/guide/build.html#library-mode)
+The build system uses Vite. It is configured to treat `./src/index.ts` as the entry point of your repository. Feel free
+to change any particulars in `./vite.config.ts`. In particular if you require multiple entry points, we recommend
+reviewing Vite's documentation on this here: [Vite Library Mode](https://vitejs.dev/guide/build.html#library-mode).
+
+In case you add direct or peer dependencies, you should uncomment following lines (and corresponding import above) to
+ensure those dependencies are not directly included in the built package.
+```tsx
+external: Object.keys(packageJson.dependencies).flatMap((dep) => [
+	dep,
+	// Include all dependency paths, not just root
+	new RegExp(`^${dep}/`),
+])
+```
 
 ## Husky
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noImplicitOverride": true,
     "noUnusedLocals": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "types": ["vitest/globals"]
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,38 @@ import { resolve } from "path";
 import { defineConfig } from "vitest/config";
 import dts from "vite-plugin-dts";
 
+// import packageJson from "./package.json";
+
 export default defineConfig({
 	build: {
 		lib: {
 			entry: resolve(__dirname, "src/index.ts"),
 			name: "YourProjectName",
 			fileName: "your-project-name",
+		},
+		rollupOptions: {
+			/**
+			 * Uncomment these lines (and import above) if you add any direct or peer dependencies.
+			 * This ensures they are not included directly in package but instead imported from node modules
+			 */
+			// external: Object.keys(packageJson.dependencies).flatMap((dep) => [
+			// 	dep,
+			// 	// Include all dependency paths, not just root
+			// 	new RegExp(`^${dep}/`),
+			// ]),
+			output: {
+				// Ensure we can tree-shake properly
+				preserveModules: true,
+				// Ensures import/require works in all environments
+				interop: "auto",
+				// Must be `false` for `preserveModules: true`
+				inlineDynamicImports: false,
+			},
+		},
+		commonjsOptions: {
+			// Assumes all external dependencies are ESM dependencies. Just ensures
+			// we then import those dependencies correctly in CJS as well.
+			esmExternals: true,
 		},
 	},
 	test: {


### PR DESCRIPTION
Improves CommonJS output, ensures compatibility with ESM.
ESM build now is split by files to enable tree-shaking.

And template is one of those places that justifies commented out code I think. :)