### PR TITLE
chore: use @lokalise/package-vite-config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@commitlint/config-conventional": "^19.2.2",
         "@commitlint/prompt-cli": "^19.3.1",
         "@lokalise/biome-config": "^1.3.0",
+        "@lokalise/package-vite-config": "^3.0.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/git": "^10.0.1",
@@ -22,7 +23,6 @@
         "semantic-release": "^24.0.0",
         "typescript": "^5.5.4",
         "vite": "^5.3.4",
-        "vite-plugin-dts": "^3.9.1",
         "vitest": "^2.0.4"
       },
       "engines": {
@@ -1092,6 +1092,18 @@
       "integrity": "sha512-NH8dG7NJBZ24nYrpjzBi/bfinLYIDHX6LKrnTGOh6ErprLVxvt+TsiF+y/sj0XkCQgklt3cAJo7IlSiWmx5X4A==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@lokalise/package-vite-config": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@lokalise/package-vite-config/-/package-vite-config-3.0.0.tgz",
+      "integrity": "sha512-MRP4FpT9PDA8dgw1xLObpjErQ/o6zhlwJhUxXVeKEl55Yndlpn2sY2ZaLGzsOV0wkj+yBr0FoX7iBikC2cMW1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "vite": "5.3.4",
+        "vite-plugin-dts": "3.9.1",
+        "vitest": "^2.0.3"
+      }
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.43.0",

--- a/package.json
+++ b/package.json
@@ -11,23 +11,27 @@
   },
   "type": "module",
   "files": ["dist"],
-  "main": "./dist/your-project-name.umd.cjs",
-  "module": "./dist/your-project-name.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/your-project-name.js",
-      "require": "./dist/your-project-name.umd.cjs"
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
     }
   },
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {},
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@commitlint/prompt-cli": "^19.3.1",
     "@lokalise/biome-config": "^1.3.0",
+    "@lokalise/package-vite-config": "^3.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/git": "^10.0.1",
@@ -37,7 +41,6 @@
     "semantic-release": "^24.0.0",
     "typescript": "^5.5.4",
     "vite": "^5.3.4",
-    "vite-plugin-dts": "^3.9.1",
     "vitest": "^2.0.4"
   },
   "engines": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,63 +1,9 @@
 import { resolve } from 'node:path'
-
-import dts from 'vite-plugin-dts'
-import { defineConfig } from 'vitest/config'
-
-// import packageJson from "./package.json";
+import defineConfig from '@lokalise/package-vite-config/package'
+import packageJson from './package.json'
 
 // biome-ignore lint/style/noDefaultExport: Vite expects default export.
 export default defineConfig({
-  build: {
-    lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'YourProjectName',
-      fileName: 'your-project-name',
-    },
-    rollupOptions: {
-      /**
-       * Uncomment these lines (and import above) if you add any direct or peer dependencies.
-       * This ensures they are not included directly in package but instead imported from node modules
-       */
-      // external: Object.keys(packageJson.dependencies).flatMap((dep) => [
-      // 	dep,
-      // 	// Include all dependency paths, not just root
-      // 	new RegExp(`^${dep}/`),
-      // ]),
-      output: {
-        // Ensure we can tree-shake properly
-        preserveModules: true,
-        // Ensures import/require works in all environments
-        interop: 'auto',
-        // Must be `false` for `preserveModules: true`
-        inlineDynamicImports: false,
-      },
-
-      /**
-       * The Rollup building process does not break on some warning, this one ensures it returns
-       * correct exit status code so the GitHub Actions can break.
-       */
-      onwarn(warning) {
-        throw Object.assign(new Error(), warning)
-      },
-    },
-    commonjsOptions: {
-      // Assumes all external dependencies are ESM dependencies. Just ensures
-      // we then import those dependencies correctly in CJS as well.
-      esmExternals: true,
-    },
-  },
-  test: {
-    globals: true,
-  },
-  plugins: [
-    dts({
-      afterDiagnostic: (diagnostics) => {
-        if (diagnostics.length > 0) {
-          throw new Error('Have issues with generating types', {
-            cause: diagnostics,
-          })
-        }
-      },
-    }),
-  ],
+  entry: resolve(__dirname, 'src/index.ts'),
+  dependencies: Object.keys(packageJson.dependencies),
 })


### PR DESCRIPTION
Simplify vite config by reusing the existing [@lokalise/package-vite-config](https://github.com/lokalise/shared-ts-libs/tree/main/packages/dev/package-vite-config) package. 